### PR TITLE
Addition of support for LabKey 17.2 to the LabKeyServer docker config.

### DIFF
--- a/docker/LabKeyServer/17.2/Dockerfile
+++ b/docker/LabKeyServer/17.2/Dockerfile
@@ -10,7 +10,7 @@
 #   * PostgreSQL: 9.5.5
 #   * Tomcat: 8.0.38
 #   * Java: 1.8u112
-#   * LabKey Server: LabKey16.3-48008.30-community-bin
+#   * LabKey Server: Labkey17.2-52553-community-bin
 #
 #
 # Storage:
@@ -42,8 +42,8 @@ MAINTAINER bconn@labkey.com
 
 ENV JAVA_VERSION=8 \
     JAVA_UPDATE=112 \
-    LABKEY_VERSION=16.3 \
-    LABKEY_DIST=16.3-48008.30-community \
+    LABKEY_VERSION=17.2 \
+    LABKEY_DIST=17.2-52553-community \
     PG_MAJOR=9.5 \
     PG_VERSION=9.5.4 \
     PG_HOST=localhost \
@@ -130,16 +130,16 @@ ADD ["./labkey/start_labkey.sh","./tomcat/start_tomcat.sh","./labkey/check_labke
 RUN chmod +x /labkey/bin/* && \
     mkdir -p /labkey/labkey && \
     cd /labkey/src && \
-    wget --no-verbose http://labkey.s3.amazonaws.com/downloads/general/r/$LABKEY_VERSION/LabKey$LABKEY_DIST-bin.tar.gz && \
-    tar xzf /labkey/src/LabKey$LABKEY_DIST-bin.tar.gz && \
-    cp -R LabKey$LABKEY_DIST-bin/modules /labkey/labkey && \
-    cp -R LabKey$LABKEY_DIST-bin/labkeywebapp /labkey/labkey && \
-    cp -R LabKey$LABKEY_DIST-bin/pipeline-lib /labkey/labkey && \
-    cp -f LabKey$LABKEY_DIST-bin/tomcat-lib/*.jar /labkey/apps/tomcat/lib/ && \
+    wget --no-verbose http://labkey.s3.amazonaws.com/downloads/general/r/$LABKEY_VERSION/Labkey$LABKEY_DIST-bin.tar.gz && \
+    tar xzf /labkey/src/Labkey$LABKEY_DIST-bin.tar.gz && \
+    cp -R Labkey$LABKEY_DIST-bin/modules /labkey/labkey && \
+    cp -R Labkey$LABKEY_DIST-bin/labkeywebapp /labkey/labkey && \
+    cp -R Labkey$LABKEY_DIST-bin/pipeline-lib /labkey/labkey && \
+    cp -f Labkey$LABKEY_DIST-bin/tomcat-lib/*.jar /labkey/apps/tomcat/lib/ && \
     mkdir /labkey/labkey/files && \
     chown -R tomcat.tomcat /labkey/labkey && \
-    rm -rf LabKey$LABKEY_DIST-bin && \
-    rm LabKey$LABKEY_DIST-bin.tar.gz
+    rm -rf Labley$LABKEY_DIST-bin && \
+    rm Labkey$LABKEY_DIST-bin.tar.gz
 
 
 # Expose LabKey Server web application
@@ -159,12 +159,3 @@ HEALTHCHECK --interval=60s --timeout=10s --retries=5 \
 
 ENTRYPOINT ["/labkey/bin/start_labkey.sh"]
 CMD ["/labkey/bin/check_labkey.sh"]
-
-
-
-
-
-
-
-
-

--- a/docker/LabKeyServer/17.2/Dockerfile
+++ b/docker/LabKeyServer/17.2/Dockerfile
@@ -1,0 +1,170 @@
+#
+# Dockerfile for running LabKey Server in a single container
+#
+# Software
+# ============
+# Software versions are specified as ENV variables. This allows
+# for a different version to be specified at build time for the image.
+#
+#   * Base: Ubuntu Core 16.04
+#   * PostgreSQL: 9.5.5
+#   * Tomcat: 8.0.38
+#   * Java: 1.8u112
+#   * LabKey Server: LabKey16.3-48008.30-community-bin
+#
+#
+# Storage:
+# =============
+# The following directories will be mounted at Data Volumes
+#   * PostgreSQL Database Directory
+#   * Tomcat logs Directory
+#   * LabKey Server Sitewide FileRoot Directory
+#
+# This allows for each backup and review of log files.
+#
+# Secrets
+# ============
+# IMPORTANT: This Dockerfile will read the required secrets (ie passwords, etc)
+# from ENV variables. There are other methods for managing secrets; feel free to
+# modify this Dockerfile or ENTRYPOINT script (start_labkey.sh) to use a
+# different method.
+#
+# The ENTRYPOINT script (/labkey/bin/start_labkey.sh) reads
+#   * PostgreSQL user account password from PG_PASSWORD ENV variable
+#   * Master Encryption Key from LABKEY_ENCRYPTION_KEY ENV variable
+#
+# You can specify values for these variables in the Dockerfile, as an ENV variable
+# during the build time or run time. We recommend specifying them as part of the run
+# command.
+
+FROM ubuntu:16.04
+MAINTAINER bconn@labkey.com
+
+ENV JAVA_VERSION=8 \
+    JAVA_UPDATE=112 \
+    LABKEY_VERSION=16.3 \
+    LABKEY_DIST=16.3-48008.30-community \
+    PG_MAJOR=9.5 \
+    PG_VERSION=9.5.4 \
+    PG_HOST=localhost \
+    TOMCAT_VERSION=8.0.38 \
+    LD_LIBRARY_PATH=/labkey/apps/postgresql/lib \
+    LABKEY_ENCRYPTION_KEY=sh8ZLBcpKAD82MtjDwhuq2BoF3m5qkctawNuWcq2qQwsRU6Vgi7O1j981JYQhRb \
+    PG_PASSWORD=tokenPassword
+
+
+#
+# Install PostgreSQL and configure
+#
+
+# For development split out apt-get calls
+#RUN apt-get update && \
+#    apt-get -y -q install build-essential ssl-cert libreadline-dev zlib1g-dev wget graphviz r-base r-recommended xvfb && \
+
+
+RUN apt-get update && \
+    apt-get -y -q install build-essential ssl-cert libreadline-dev zlib1g-dev wget graphviz r-base r-recommended xvfb curl && \
+    mkdir -p /labkey/apps/postgresql && \
+    mkdir -p /labkey/src/labkey && \
+    mkdir -p /labkey/bin && \
+    cd /labkey/src && \
+    wget --no-verbose http://ftp.postgresql.org/pub/source/v$PG_VERSION/postgresql-$PG_VERSION.tar.gz && \
+    tar xzf postgresql-$PG_VERSION.tar.gz && \
+    cd /labkey/src/postgresql-$PG_VERSION && \
+    ./configure --prefix=/labkey/apps/postgresql && \
+    make && \
+    make install && \
+    rm -rf /labkey/src/postgresql-$PG_VERSION && \
+    rm /labkey/src/postgresql-$PG_VERSION.tar.gz && \
+    apt-get -y -q purge build-essential && \
+    apt-get -y -q autoremove && \
+    apt-get clean -y
+
+
+# Create PostgreSQL and Tomcat user account and set directory permissions
+RUN useradd -m -u 2900 postgres && \
+    useradd -m -u 3000 tomcat && \
+    mkdir /labkey/apps/postgresql/data && \
+    chown postgres.postgres /labkey/apps/postgresql/data
+
+
+# Initialize PostgreSQL database, start PostgreSQL server and create user account to be used by LabKey Server
+USER postgres
+RUN /labkey/apps/postgresql/bin/initdb --locale=C.UTF-8 -D /labkey/apps/postgresql/data && \
+    mkdir /labkey/apps/postgresql/data/pg_log && \
+    mkdir /labkey/apps/postgresql/data/backup
+
+
+# Add configuration file to PGDATA directory and restart the PostgreSQL server
+ADD ./postgresql/postgresql.conf /labkey/apps/postgresql/data/postgresql.conf
+ADD ./postgresql/pg_hba.conf /labkey/apps/postgresql/data/pg_hba.conf
+USER root
+
+
+#
+# Install Tomcat and configure
+#
+RUN cd /labkey/src && \
+    wget --no-verbose http://archive.apache.org/dist/tomcat/tomcat-8/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.tar.gz && \
+    tar xzf apache-tomcat-$TOMCAT_VERSION.tar.gz && \
+    mv apache-tomcat-$TOMCAT_VERSION /labkey/apps/tomcat && \
+    mkdir -p /labkey/apps/tomcat/conf/Catalina/localhost && \
+    mkdir -p /labkey/apps/tomcat/temp && \
+    chown -R tomcat.tomcat /labkey/apps/tomcat && \
+    rm /labkey/src/apache-tomcat-$TOMCAT_VERSION.tar.gz && \
+    wget --no-verbose http://www.labkey.org/download/g/server-jre-"$JAVA_VERSION"u$JAVA_UPDATE-linux-x64.tar.gz && \
+    tar xzf server-jre-"$JAVA_VERSION"u$JAVA_UPDATE-linux-x64.tar.gz && \
+    mv jdk1.$JAVA_VERSION.0_$JAVA_UPDATE /labkey/apps/java && \
+    rm server-jre-"$JAVA_VERSION"u$JAVA_UPDATE-linux-x64.tar.gz
+
+
+# Add configuration files and scripts
+ADD ./tomcat/server.xml /labkey/apps/tomcat/conf/server.xml
+ADD ./labkey/labkey.xml /labkey/apps/tomcat/conf/Catalina/localhost/ROOT.xml
+ADD ["./labkey/start_labkey.sh","./tomcat/start_tomcat.sh","./labkey/check_labkey.sh", "/labkey/bin/"]
+
+#
+# Install the LabKey Server and Configure
+#
+
+RUN chmod +x /labkey/bin/* && \
+    mkdir -p /labkey/labkey && \
+    cd /labkey/src && \
+    wget --no-verbose http://labkey.s3.amazonaws.com/downloads/general/r/$LABKEY_VERSION/LabKey$LABKEY_DIST-bin.tar.gz && \
+    tar xzf /labkey/src/LabKey$LABKEY_DIST-bin.tar.gz && \
+    cp -R LabKey$LABKEY_DIST-bin/modules /labkey/labkey && \
+    cp -R LabKey$LABKEY_DIST-bin/labkeywebapp /labkey/labkey && \
+    cp -R LabKey$LABKEY_DIST-bin/pipeline-lib /labkey/labkey && \
+    cp -f LabKey$LABKEY_DIST-bin/tomcat-lib/*.jar /labkey/apps/tomcat/lib/ && \
+    mkdir /labkey/labkey/files && \
+    chown -R tomcat.tomcat /labkey/labkey && \
+    rm -rf LabKey$LABKEY_DIST-bin && \
+    rm LabKey$LABKEY_DIST-bin.tar.gz
+
+
+# Expose LabKey Server web application
+EXPOSE 8080
+
+# Add VOLUMEs to allow backup of Tomcat logs, database and Sitewide FileRoot
+VOLUME  ["/labkey/apps/postgresql/data", "/labkey/labkey/files", "/labkey/apps/tomcat/logs"]
+
+#
+# Start Tomcat and PostgreSQL Daemons when container is started.
+#
+WORKDIR /labkey/
+
+# Configure healthcheck for container
+HEALTHCHECK --interval=60s --timeout=10s --retries=5 \
+    CMD curl -fsS http://localhost:8080/ > /dev/null || exit 1
+
+ENTRYPOINT ["/labkey/bin/start_labkey.sh"]
+CMD ["/labkey/bin/check_labkey.sh"]
+
+
+
+
+
+
+
+
+

--- a/docker/LabKeyServer/17.2/Dockerfile-ssl
+++ b/docker/LabKeyServer/17.2/Dockerfile-ssl
@@ -10,7 +10,7 @@
 #   * PostgreSQL: 9.5.5
 #   * Tomcat: 8.0.38
 #   * Java: 1.8u112
-#   * LabKey Server: LabKey16.3-48008.30-community-bin
+#   * LabKey Server: Labkey17.2-52553-community-bin
 #
 #
 # Storage:
@@ -42,8 +42,8 @@ MAINTAINER bconn@labkey.com
 
 ENV JAVA_VERSION=8 \
     JAVA_UPDATE=112 \
-    LABKEY_VERSION=16.3 \
-    LABKEY_DIST=16.3-48008.30-community \
+    LABKEY_VERSION=17.2 \
+    LABKEY_DIST=17.2-52553-community \
     PG_MAJOR=9.5 \
     PG_VERSION=9.5.4 \
     PG_HOST=localhost \
@@ -140,16 +140,16 @@ ADD ["./labkey/start_labkey.sh","./tomcat/start_tomcat.sh","./labkey/check_labke
 RUN chmod +x /labkey/bin/* && \
     mkdir -p /labkey/labkey && \
     cd /labkey/src && \
-    wget --no-verbose http://labkey.s3.amazonaws.com/downloads/general/r/$LABKEY_VERSION/LabKey$LABKEY_DIST-bin.tar.gz && \
-    tar xzf /labkey/src/LabKey$LABKEY_DIST-bin.tar.gz && \
-    cp -R LabKey$LABKEY_DIST-bin/modules /labkey/labkey && \
-    cp -R LabKey$LABKEY_DIST-bin/labkeywebapp /labkey/labkey && \
-    cp -R LabKey$LABKEY_DIST-bin/pipeline-lib /labkey/labkey && \
-    cp -f LabKey$LABKEY_DIST-bin/tomcat-lib/*.jar /labkey/apps/tomcat/lib/ && \
+    wget --no-verbose http://labkey.s3.amazonaws.com/downloads/general/r/$LABKEY_VERSION/Labkey$LABKEY_DIST-bin.tar.gz && \
+    tar xzf /labkey/src/Labkey$LABKEY_DIST-bin.tar.gz && \
+    cp -R Labkey$LABKEY_DIST-bin/modules /labkey/labkey && \
+    cp -R Labkey$LABKEY_DIST-bin/labkeywebapp /labkey/labkey && \
+    cp -R Labkey$LABKEY_DIST-bin/pipeline-lib /labkey/labkey && \
+    cp -f Labkey$LABKEY_DIST-bin/tomcat-lib/*.jar /labkey/apps/tomcat/lib/ && \
     mkdir /labkey/labkey/files && \
     chown -R tomcat.tomcat /labkey/labkey && \
-    rm -rf LabKey$LABKEY_DIST-bin && \
-    rm LabKey$LABKEY_DIST-bin.tar.gz
+    rm -rf Labley$LABKEY_DIST-bin && \
+    rm Labkey$LABKEY_DIST-bin.tar.gz
 
 
 # Expose LabKey Server web application
@@ -169,12 +169,3 @@ HEALTHCHECK --interval=60s --timeout=10s --retries=5 \
 
 ENTRYPOINT ["/labkey/bin/start_labkey.sh"]
 CMD ["/labkey/bin/check_labkey.sh"]
-
-
-
-
-
-
-
-
-

--- a/docker/LabKeyServer/17.2/Dockerfile-ssl
+++ b/docker/LabKeyServer/17.2/Dockerfile-ssl
@@ -1,0 +1,180 @@
+#
+# Dockerfile for running LabKey Server in a single container
+#
+# Software
+# ============
+# Software versions are specified as ENV variables. This allows
+# for a different version to be specified at build time for the image.
+#
+#   * Base: Ubuntu Core 16.04
+#   * PostgreSQL: 9.5.5
+#   * Tomcat: 8.0.38
+#   * Java: 1.8u112
+#   * LabKey Server: LabKey16.3-48008.30-community-bin
+#
+#
+# Storage:
+# =============
+# The following directories will be mounted at Data Volumes
+#   * PostgreSQL Database Directory
+#   * Tomcat logs Directory
+#   * LabKey Server Sitewide FileRoot Directory
+#
+# This allows for each backup and review of log files.
+#
+# Secrets
+# ============
+# IMPORTANT: This Dockerfile will read the required secrets (ie passwords, etc)
+# from ENV variables. There are other methods for managing secrets; feel free to
+# modify this Dockerfile or ENTRYPOINT script (start_labkey.sh) to use a
+# different method.
+#
+# The ENTRYPOINT script (/labkey/bin/start_labkey.sh) reads
+#   * PostgreSQL user account password from PG_PASSWORD ENV variable
+#   * Master Encryption Key from LABKEY_ENCRYPTION_KEY ENV variable
+#
+# You can specify values for these variables in the Dockerfile, as an ENV variable
+# during the build time or run time. We recommend specifying them as part of the run
+# command.
+
+FROM ubuntu:16.04
+MAINTAINER bconn@labkey.com
+
+ENV JAVA_VERSION=8 \
+    JAVA_UPDATE=112 \
+    LABKEY_VERSION=16.3 \
+    LABKEY_DIST=16.3-48008.30-community \
+    PG_MAJOR=9.5 \
+    PG_VERSION=9.5.4 \
+    PG_HOST=localhost \
+    TOMCAT_VERSION=8.0.38 \
+    LD_LIBRARY_PATH=/labkey/apps/postgresql/lib \
+    LABKEY_ENCRYPTION_KEY=sh8ZLBcpKAD82MtjDwhuq2BoF3m5qkctawNuWcq2qQwsRU6Vgi7O1j981JYQhRb \
+    PG_PASSWORD=tokenPassword \
+    KEYSTORE_PASSPHRASE=changeitnow
+
+
+#
+# Install PostgreSQL and configure
+#
+
+# For development split out apt-get calls
+#RUN apt-get update && \
+#    apt-get -y -q install build-essential ssl-cert libreadline-dev zlib1g-dev wget graphviz r-base r-recommended xvfb && \
+
+
+RUN apt-get update && \
+    apt-get -y -q install build-essential ssl-cert libreadline-dev zlib1g-dev wget graphviz r-base r-recommended xvfb curl && \
+    mkdir -p /labkey/apps/postgresql && \
+    mkdir -p /labkey/src/labkey && \
+    mkdir -p /labkey/bin && \
+    cd /labkey/src && \
+    wget --no-verbose http://ftp.postgresql.org/pub/source/v$PG_VERSION/postgresql-$PG_VERSION.tar.gz && \
+    tar xzf postgresql-$PG_VERSION.tar.gz && \
+    cd /labkey/src/postgresql-$PG_VERSION && \
+    ./configure --prefix=/labkey/apps/postgresql && \
+    make && \
+    make install && \
+    rm -rf /labkey/src/postgresql-$PG_VERSION && \
+    rm /labkey/src/postgresql-$PG_VERSION.tar.gz && \
+    apt-get -y -q purge build-essential && \
+    apt-get -y -q autoremove && \
+    apt-get clean -y
+
+
+# Create PostgreSQL and Tomcat user account and set directory permissions
+RUN useradd -m -u 2900 postgres && \
+    useradd -m -u 3000 tomcat && \
+    mkdir /labkey/apps/postgresql/data && \
+    chown postgres.postgres /labkey/apps/postgresql/data
+
+
+# Initialize PostgreSQL database, start PostgreSQL server and create user account to be used by LabKey Server
+USER postgres
+RUN /labkey/apps/postgresql/bin/initdb --locale=C.UTF-8 -D /labkey/apps/postgresql/data && \
+    mkdir /labkey/apps/postgresql/data/pg_log && \
+    mkdir /labkey/apps/postgresql/data/backup
+
+
+# Add configuration file to PGDATA directory and restart the PostgreSQL server
+ADD ./postgresql/postgresql.conf /labkey/apps/postgresql/data/postgresql.conf
+ADD ./postgresql/pg_hba.conf /labkey/apps/postgresql/data/pg_hba.conf
+USER root
+
+
+#
+# Install Tomcat and configure
+#
+RUN cd /labkey/src && \
+    wget --no-verbose http://archive.apache.org/dist/tomcat/tomcat-8/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.tar.gz && \
+    tar xzf apache-tomcat-$TOMCAT_VERSION.tar.gz && \
+    mv apache-tomcat-$TOMCAT_VERSION /labkey/apps/tomcat && \
+    mkdir -p /labkey/apps/tomcat/conf/Catalina/localhost && \
+    mkdir -p /labkey/apps/tomcat/temp && \
+    chown -R tomcat.tomcat /labkey/apps/tomcat && \
+    rm /labkey/src/apache-tomcat-$TOMCAT_VERSION.tar.gz && \
+    wget --no-verbose http://www.labkey.org/download/g/server-jre-"$JAVA_VERSION"u$JAVA_UPDATE-linux-x64.tar.gz && \
+    tar xzf server-jre-"$JAVA_VERSION"u$JAVA_UPDATE-linux-x64.tar.gz && \
+    mv jdk1.$JAVA_VERSION.0_$JAVA_UPDATE /labkey/apps/java && \
+    rm server-jre-"$JAVA_VERSION"u$JAVA_UPDATE-linux-x64.tar.gz
+
+#
+# Install Keystore to be used for HTTPS connectory
+#
+RUN mkdir /labkey/apps/SSL && \
+    chown tomcat /labkey/apps/SSL
+USER tomcat
+ADD ./tomcat/keystore.tomcat /labkey/apps/SSL/keystore.tomcat
+USER root
+
+
+# Add configuration files and scripts
+ADD ./tomcat/server-ssl.xml /labkey/apps/tomcat/conf/server.xml
+ADD ./labkey/labkey.xml /labkey/apps/tomcat/conf/Catalina/localhost/ROOT.xml
+ADD ["./labkey/start_labkey.sh","./tomcat/start_tomcat.sh","./labkey/check_labkey.sh", "/labkey/bin/"]
+
+#
+# Install the LabKey Server and Configure
+#
+
+RUN chmod +x /labkey/bin/* && \
+    mkdir -p /labkey/labkey && \
+    cd /labkey/src && \
+    wget --no-verbose http://labkey.s3.amazonaws.com/downloads/general/r/$LABKEY_VERSION/LabKey$LABKEY_DIST-bin.tar.gz && \
+    tar xzf /labkey/src/LabKey$LABKEY_DIST-bin.tar.gz && \
+    cp -R LabKey$LABKEY_DIST-bin/modules /labkey/labkey && \
+    cp -R LabKey$LABKEY_DIST-bin/labkeywebapp /labkey/labkey && \
+    cp -R LabKey$LABKEY_DIST-bin/pipeline-lib /labkey/labkey && \
+    cp -f LabKey$LABKEY_DIST-bin/tomcat-lib/*.jar /labkey/apps/tomcat/lib/ && \
+    mkdir /labkey/labkey/files && \
+    chown -R tomcat.tomcat /labkey/labkey && \
+    rm -rf LabKey$LABKEY_DIST-bin && \
+    rm LabKey$LABKEY_DIST-bin.tar.gz
+
+
+# Expose LabKey Server web application
+EXPOSE 8080 8443
+
+# Add VOLUMEs to allow backup of Tomcat logs, database and Sitewide FileRoot
+VOLUME  ["/labkey/apps/postgresql/data", "/labkey/labkey/files", "/labkey/apps/tomcat/logs"]
+
+#
+# Start Tomcat and PostgreSQL Daemons when container is started.
+#
+WORKDIR /labkey/
+
+# Configure healthcheck for container
+HEALTHCHECK --interval=60s --timeout=10s --retries=5 \
+    CMD curl -fsS http://localhost:8080/ > /dev/null || exit 1
+
+ENTRYPOINT ["/labkey/bin/start_labkey.sh"]
+CMD ["/labkey/bin/check_labkey.sh"]
+
+
+
+
+
+
+
+
+

--- a/docker/LabKeyServer/17.2/README.md
+++ b/docker/LabKeyServer/17.2/README.md
@@ -1,4 +1,4 @@
-# samples/docker/LabKeyServer/16.3
+# samples/docker/LabKeyServer/17.2
 
 This folder contains a Dockerfile, scripts and instructions for building a Docker image can be used to try out LabKey Server. Using this Dockerfile will result in a single container which runs the services required(PostgreSQL and Tomcat) to run a LabKey Server application.
 
@@ -8,7 +8,7 @@ This Dockerfile will install following software in the container
 * PostgreSQL: `9.5.5`
 * Tomcat: `8.0.38`
 * Java: `1.8u112`
-* LabKey Server: `LabKey16.3-48008.30-community-bin`
+* LabKey Server: `Labkey17.2-52553-community-bin`
 
 
 This Dockerfile also creates three VOLUMES. These volumes will hold all persistent data that will be created while using LabKey Server.
@@ -23,110 +23,110 @@ This Dockerfile also creates three VOLUMES. These volumes will hold all persiste
 
 
 
-## Usage 
+## Usage
 
-How to build an image for this dockerfile 
+How to build an image for this dockerfile
 
     cd samples/docker/labkeyserver-single
-    docker build -t labkeyserver:16.3 .
+    docker build -t labkeyserver:17.2 .
 
-This command will take a couple of minutes to complete. 
+This command will take a couple of minutes to complete.
 
 
 How to run the container from this image
 
-    docker run -p 8080:8080 --name LabKeyServer_16.3 labkeyserver:16.3 
+    docker run -p 8080:8080 --name LabKeyServer_17.2 labkeyserver:17.2
 
 
-Once the container is started, you should be able to access the LabKey Server by opening your browser and going to either 
+Once the container is started, you should be able to access the LabKey Server by opening your browser and going to either
 
-* [http://<container-ip>:8080](http://<container-ip>:8080) or 
+* [http://<container-ip>:8080](http://<container-ip>:8080) or
 * [http://<dockerhost>:8080](http://<dockerhost>:8080)
 
 
-**RECOMMENDED**: If you would like change the PostgreSQL password and Master Encryption Key used by the LabKey Server application these can be specified as ENV variables when you execute `docker run ....`. To do this you would first create an ENV file 
+**RECOMMENDED**: If you would like change the PostgreSQL password and Master Encryption Key used by the LabKey Server application these can be specified as ENV variables when you execute `docker run ....`. To do this you would first create an ENV file
 
-    vi LabKeyServer_16.3_env-file
+    vi LabKeyServer_17.2_env-file
     (add)
     PG_PASSWORD=new-password
     LABKEY_ENCRYPTION_KEY=verylongstringtobeusedForEncryptingPropertyStore122222
 
-Now you can create a new container, which uses these values by running 
+Now you can create a new container, which uses these values by running
 
-    docker run --env-file ./LabKeyServer_16.3_env-file -p 8080:8080 --name LabKeyServer_16.3 labkeyserver:16.3
+    docker run --env-file ./LabKeyServer_17.2_env-file -p 8080:8080 --name LabKeyServer_17.2 labkeyserver:17.2
 
 
-### Usage Notes 
+### Usage Notes
 
-* Add the `--rm` command line option to the `docker run` if you would like the container removed when it exits (please note, this will also remove the container volumes contain PostgreSQL database and Sitewide FileRoot) 
+* Add the `--rm` command line option to the `docker run` if you would like the container removed when it exits (please note, this will also remove the container volumes contain PostgreSQL database and Sitewide FileRoot)
 * This Dockerfile will create 3 volumes, when the removing the container use the `-v` option to remove the data in these volumes also. See [here](https://docs.docker.com/engine/tutorials/dockervolumes/#removing-volumes) for more information.
 
 
 
 
-## Start and Stop the Container 
+## Start and Stop the Container
 
-If you want to stop the container, you can run 
+If you want to stop the container, you can run
 
-    docker stop LabKeyServer_16.3
+    docker stop LabKeyServer_17.2
 
-This will stop Tomcat, PostgreSQL and XVFB servers and then stop the container 
+This will stop Tomcat, PostgreSQL and XVFB servers and then stop the container
 
-To restart the container, run 
+To restart the container, run
 
-    docker start LabKeyServer_16.3
+    docker start LabKeyServer_17.2
 
 This will execute the ENTRYPOINT and CMD statements in the dockerfile again.
 
-### Usage Notes 
+### Usage Notes
 
 * When using this `--rm` command line option, stopping the container will result in the container and all volumes being deleted
 
 
 
 
-## Backup Data and Files used by LabKey Server application 
+## Backup Data and Files used by LabKey Server application
 
-There are number of options for how the database and files in the running container can be backed up. One option is described below. 
+There are number of options for how the database and files in the running container can be backed up. One option is described below.
 
-### Backup the LabKey Server Database 
-For this you will be need to execute two commands. The first command use `docker exec` to execute `pgdump` in the `LabKeyServer_16.3` container. The second will start a new container which will have access to all volumes mounted on the `LabKeyServer_16.3` container and copy the backup file to the local directory
+### Backup the LabKey Server Database
+For this you will be need to execute two commands. The first command use `docker exec` to execute `pgdump` in the `LabKeyServer_17.2` container. The second will start a new container which will have access to all volumes mounted on the `LabKeyServer_17.2` container and copy the backup file to the local directory
 
-    docker exec -u postgres -t LabKeyServer_16.3 bash -c "/labkey/apps/postgresql/bin/pg_dump --format=c --compress=9 -f /labkey/apps/postgresql/data/backup/postgres_labkey_$(date +%Y%m%d).bak labkey"
+    docker exec -u postgres -t LabKeyServer_17.2 bash -c "/labkey/apps/postgresql/bin/pg_dump --format=c --compress=9 -f /labkey/apps/postgresql/data/backup/postgres_labkey_$(date +%Y%m%d).bak labkey"
 
-The second command will start a new container which will have access to all volumes mounted on the `LabKeyServer_16.3` container and copy the backup file to the local directory
+The second command will start a new container which will have access to all volumes mounted on the `LabKeyServer_17.2` container and copy the backup file to the local directory
 
-    docker run --rm --volumes-from LabKeyServer_16.3 -v $(pwd):/backup ubuntu bash -c "cp /labkey/apps/postgresql/data/backup/postgres_labkey_$(date +%Y%m%d).bak /backup/"
+    docker run --rm --volumes-from LabKeyServer_17.2 -v $(pwd):/backup ubuntu bash -c "cp /labkey/apps/postgresql/data/backup/postgres_labkey_$(date +%Y%m%d).bak /backup/"
 
 
 ### Backup the files in the Sitewide FileRoot
-For this you will start a new container which will have access to all volumes mounted on the `LabKeyServer_16.3` container and use the `tar` command to backup all the files and directories.
+For this you will start a new container which will have access to all volumes mounted on the `LabKeyServer_17.2` container and use the `tar` command to backup all the files and directories.
 
-    docker run --rm --volumes-from LabKeyServer_16.3 -v $(pwd):/backup ubuntu bash -c "tar czf /backup/fileroot_$(date +%Y%m%d).tar.gz /labkey/labkey/files "
-
-
-### Backup the LabKey Server log files 
-For this you will start a new container which will have access to all volumes mounted on the `LabKeyServer_16.3` container and use the `tar` command to backup all the files and directories.
-
-    docker run --rm --volumes-from LabKeyServer_16.3 -v $(pwd):/backup ubuntu bash -c "tar czf /backup/labkey_logs_$(date +%Y%m%d).tar.gz /labkey/apps/tomcat/logs "
+    docker run --rm --volumes-from LabKeyServer_17.2 -v $(pwd):/backup ubuntu bash -c "tar czf /backup/fileroot_$(date +%Y%m%d).tar.gz /labkey/labkey/files "
 
 
-## Use a different version of LabKey Server 
+### Backup the LabKey Server log files
+For this you will start a new container which will have access to all volumes mounted on the `LabKeyServer_17.2` container and use the `tar` command to backup all the files and directories.
 
-If you would like to create a Docker image and container which runs a different version of LabKey Server you can run a command similar to 
+    docker run --rm --volumes-from LabKeyServer_17.2 -v $(pwd):/backup ubuntu bash -c "tar czf /backup/labkey_logs_$(date +%Y%m%d).tar.gz /labkey/apps/tomcat/logs "
+
+
+## Use a different version of LabKey Server
+
+If you would like to create a Docker image and container which runs a different version of LabKey Server you can run a command similar to
 
     cd samples/docker/labkeyserver-single
-    docker build --build-arg LABKEY_DIST=16.3-49086.73-community -t labkeyserver:16.3-49086 .
+    docker build --build-arg LABKEY_DIST=17.2-49086.73-community -t labkeyserver:17.2-49086 .
 
-Where `16.3-49086.73-community` is the new build version that you would like to use in the container. 
-
-
+Where `17.2-49086.73-community` is the new build version that you would like to use in the container.
 
 
-## Use SSL in the Container 
-If you would like to use SSL when connecting to your LabKey Server you can use the `Dockerfile-ssl` dockerfile. To use this file, you will need to 
 
-1. Create a Java Keystore 
+
+## Use SSL in the Container
+If you would like to use SSL when connecting to your LabKey Server you can use the `Dockerfile-ssl` dockerfile. To use this file, you will need to
+
+1. Create a Java Keystore
 2. Place the keystore file in `./tomcat` directory and name it `keystore.tomcat`
 3. When starting the image, specify the keystore passphrase using the `KEYSTORE_PASSPHRASE` ENV variable
 
@@ -137,25 +137,25 @@ If you do not have a Java keystore file already created, you can use the command
     * Change the storepass and keypass variables to a different value
 
 
-Now that this is created, you can start a new container by running 
+Now that this is created, you can start a new container by running
 
-    docker build -t labkeyserver-ssl:16.3 -f Dockerfile-ssl .
+    docker build -t labkeyserver-ssl:17.2 -f Dockerfile-ssl .
 
-This command will take a couple of minutes to complete. 
+This command will take a couple of minutes to complete.
 
 
 How to run the container from this image
 
-    docker run -p 8080:8080 -p 8443:8443 --env KEYSTORE_PASSPHRASE=changeitnow --name LabKeyServerSSL_16.3 labkeyserver-ssl:16.3
+    docker run -p 8080:8080 -p 8443:8443 --env KEYSTORE_PASSPHRASE=changeitnow --name LabKeyServerSSL_17.2 labkeyserver-ssl:17.2
 
 
 
 
-## Additional Commands that might be of interest 
+## Additional Commands that might be of interest
 
-### Removing Container Volumes 
+### Removing Container Volumes
 
-To remove a container and it's volumes, you can run 
+To remove a container and it's volumes, you can run
 
     docker rm -v CONTAINERNAME
 
@@ -166,17 +166,3 @@ To view the volumes that were associated with containers that have been deleted 
 To remove volumes that were associated with containers that have been deleted run
 
     docker volume rm $(docker volume ls -qf dangling=true)
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/docker/LabKeyServer/17.2/README.md
+++ b/docker/LabKeyServer/17.2/README.md
@@ -1,0 +1,182 @@
+# samples/docker/LabKeyServer/16.3
+
+This folder contains a Dockerfile, scripts and instructions for building a Docker image can be used to try out LabKey Server. Using this Dockerfile will result in a single container which runs the services required(PostgreSQL and Tomcat) to run a LabKey Server application.
+
+This Dockerfile will install following software in the container
+
+* Base: `Ubuntu Core 16.04`
+* PostgreSQL: `9.5.5`
+* Tomcat: `8.0.38`
+* Java: `1.8u112`
+* LabKey Server: `LabKey16.3-48008.30-community-bin`
+
+
+This Dockerfile also creates three VOLUMES. These volumes will hold all persistent data that will be created while using LabKey Server.
+
+* Sitewide FileRoot: `/labkey/labkey/files`
+* LabKey Server log files: `/labkey/apps/tomcat/logs`
+* PostgreSQL Data Directory: `/labkey/apps/postgresql/data`
+
+
+**IMPORTANT:** This image was meant for trying out LabKey Server and not meant for running a production server or for storing important biomedical data.
+
+
+
+
+## Usage 
+
+How to build an image for this dockerfile 
+
+    cd samples/docker/labkeyserver-single
+    docker build -t labkeyserver:16.3 .
+
+This command will take a couple of minutes to complete. 
+
+
+How to run the container from this image
+
+    docker run -p 8080:8080 --name LabKeyServer_16.3 labkeyserver:16.3 
+
+
+Once the container is started, you should be able to access the LabKey Server by opening your browser and going to either 
+
+* [http://<container-ip>:8080](http://<container-ip>:8080) or 
+* [http://<dockerhost>:8080](http://<dockerhost>:8080)
+
+
+**RECOMMENDED**: If you would like change the PostgreSQL password and Master Encryption Key used by the LabKey Server application these can be specified as ENV variables when you execute `docker run ....`. To do this you would first create an ENV file 
+
+    vi LabKeyServer_16.3_env-file
+    (add)
+    PG_PASSWORD=new-password
+    LABKEY_ENCRYPTION_KEY=verylongstringtobeusedForEncryptingPropertyStore122222
+
+Now you can create a new container, which uses these values by running 
+
+    docker run --env-file ./LabKeyServer_16.3_env-file -p 8080:8080 --name LabKeyServer_16.3 labkeyserver:16.3
+
+
+### Usage Notes 
+
+* Add the `--rm` command line option to the `docker run` if you would like the container removed when it exits (please note, this will also remove the container volumes contain PostgreSQL database and Sitewide FileRoot) 
+* This Dockerfile will create 3 volumes, when the removing the container use the `-v` option to remove the data in these volumes also. See [here](https://docs.docker.com/engine/tutorials/dockervolumes/#removing-volumes) for more information.
+
+
+
+
+## Start and Stop the Container 
+
+If you want to stop the container, you can run 
+
+    docker stop LabKeyServer_16.3
+
+This will stop Tomcat, PostgreSQL and XVFB servers and then stop the container 
+
+To restart the container, run 
+
+    docker start LabKeyServer_16.3
+
+This will execute the ENTRYPOINT and CMD statements in the dockerfile again.
+
+### Usage Notes 
+
+* When using this `--rm` command line option, stopping the container will result in the container and all volumes being deleted
+
+
+
+
+## Backup Data and Files used by LabKey Server application 
+
+There are number of options for how the database and files in the running container can be backed up. One option is described below. 
+
+### Backup the LabKey Server Database 
+For this you will be need to execute two commands. The first command use `docker exec` to execute `pgdump` in the `LabKeyServer_16.3` container. The second will start a new container which will have access to all volumes mounted on the `LabKeyServer_16.3` container and copy the backup file to the local directory
+
+    docker exec -u postgres -t LabKeyServer_16.3 bash -c "/labkey/apps/postgresql/bin/pg_dump --format=c --compress=9 -f /labkey/apps/postgresql/data/backup/postgres_labkey_$(date +%Y%m%d).bak labkey"
+
+The second command will start a new container which will have access to all volumes mounted on the `LabKeyServer_16.3` container and copy the backup file to the local directory
+
+    docker run --rm --volumes-from LabKeyServer_16.3 -v $(pwd):/backup ubuntu bash -c "cp /labkey/apps/postgresql/data/backup/postgres_labkey_$(date +%Y%m%d).bak /backup/"
+
+
+### Backup the files in the Sitewide FileRoot
+For this you will start a new container which will have access to all volumes mounted on the `LabKeyServer_16.3` container and use the `tar` command to backup all the files and directories.
+
+    docker run --rm --volumes-from LabKeyServer_16.3 -v $(pwd):/backup ubuntu bash -c "tar czf /backup/fileroot_$(date +%Y%m%d).tar.gz /labkey/labkey/files "
+
+
+### Backup the LabKey Server log files 
+For this you will start a new container which will have access to all volumes mounted on the `LabKeyServer_16.3` container and use the `tar` command to backup all the files and directories.
+
+    docker run --rm --volumes-from LabKeyServer_16.3 -v $(pwd):/backup ubuntu bash -c "tar czf /backup/labkey_logs_$(date +%Y%m%d).tar.gz /labkey/apps/tomcat/logs "
+
+
+## Use a different version of LabKey Server 
+
+If you would like to create a Docker image and container which runs a different version of LabKey Server you can run a command similar to 
+
+    cd samples/docker/labkeyserver-single
+    docker build --build-arg LABKEY_DIST=16.3-49086.73-community -t labkeyserver:16.3-49086 .
+
+Where `16.3-49086.73-community` is the new build version that you would like to use in the container. 
+
+
+
+
+## Use SSL in the Container 
+If you would like to use SSL when connecting to your LabKey Server you can use the `Dockerfile-ssl` dockerfile. To use this file, you will need to 
+
+1. Create a Java Keystore 
+2. Place the keystore file in `./tomcat` directory and name it `keystore.tomcat`
+3. When starting the image, specify the keystore passphrase using the `KEYSTORE_PASSPHRASE` ENV variable
+
+If you do not have a Java keystore file already created, you can use the command below to create a new keystore which contains a self-signed certificate.
+
+    /labkey/apps/java/bin/keytool -genkey -dname "CN=dockerhost, OU=LabKey, O=LabKey, L=Seattle, S=Washington, C=US" -alias tomcat -keystore ./tomcat/keystore.tomcat -storepass changeitnow -keypass changeitnow -keyalg RSA -keysize 2048 -validity 730 -storetype pkcs12
+
+    * Change the storepass and keypass variables to a different value
+
+
+Now that this is created, you can start a new container by running 
+
+    docker build -t labkeyserver-ssl:16.3 -f Dockerfile-ssl .
+
+This command will take a couple of minutes to complete. 
+
+
+How to run the container from this image
+
+    docker run -p 8080:8080 -p 8443:8443 --env KEYSTORE_PASSPHRASE=changeitnow --name LabKeyServerSSL_16.3 labkeyserver-ssl:16.3
+
+
+
+
+## Additional Commands that might be of interest 
+
+### Removing Container Volumes 
+
+To remove a container and it's volumes, you can run 
+
+    docker rm -v CONTAINERNAME
+
+To view the volumes that were associated with containers that have been deleted run
+
+    docker volume ls -f dangling=true
+
+To remove volumes that were associated with containers that have been deleted run
+
+    docker volume rm $(docker volume ls -qf dangling=true)
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/docker/LabKeyServer/17.2/labkey/check_labkey.sh
+++ b/docker/LabKeyServer/17.2/labkey/check_labkey.sh
@@ -1,0 +1,123 @@
+#!/bin/bash
+#
+#
+# Copyright (c) 2016-2017 LabKey Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Simple script to
+#   1. Monitor if Tomcat process is running. If not, stop the container
+#   2. Listen for incoming SIGNALS from docker daemon and handle
+#      them properly.
+#
+
+stop_labkey()
+{
+
+    #
+    # Stop Tomcat:
+    #
+    # If Tomcat process is not running, then skip step
+    PID=$(/bin/ps ax | grep bootstrap.jar | grep catalina)
+    if [ -n "$PID" ]
+    then
+        echo "TOMCAT: Stopping Tomcat Server"
+        INSTALLDIR=/labkey/apps/tomcat
+
+        # Start Tomcat Server
+        if ! /labkey/bin/start_tomcat.sh stop
+        then
+            echo "WARNING: TOMCAT did not stop in a timely fashion"
+        fi
+    fi
+
+    #
+    # Stop PostgreSQL
+    #
+    echo "POSTGRESQL SERVER:  Stopping PostgreSQL Server"
+    INSTALLDIR=/labkey/apps/postgresql
+    PGDATA=$INSTALLDIR/data
+    BINDIR=$INSTALLDIR/bin
+    if su - postgres -c "$BINDIR/pg_ctl -w stop -D \"$PGDATA\"";
+    then
+        echo "POSTGRESQL SERVER stopped successfully"
+    else
+        echo "WARNING: POSTGRESQL SERVER shutdown returned an error. The server may still be running"
+    fi
+    echo ""
+
+    #
+    # Stop X Virtual Frame Buffer
+    #
+    XVFB_LOCKFILE=/tmp/.X2-lock
+    echo "X VIRTUAL FRAME BUFFER: Stopping Process "
+    if [ -f "$XVFB_LOCKFILE" ]
+    then
+        PID="$(< /tmp/.X2-lock xargs)"
+        if kill "$PID"
+        then
+            echo "X VIRTUAL FRAME BUFFER stopped successfully"
+            sleep 2
+        else
+            echo "ERROR: VIRTUAL FRAME BUFFER did not stop properly"
+        fi
+    fi
+
+    exit "$TOMCAT_RUNNING"
+
+}
+
+#
+# This script will listen for SIGINT and SIGTERM signals
+# and execute stop_labkey function if they are recieved.
+#
+# SIGINT signal will be sent to this process when an administrator runs "docker stop:
+# SIGTERM signal will be sent to this process when and administator
+#   * runs "docker kill" or
+#   * if the SIGINT signal sent by "docker stop" does to successful stop the terminal
+#     after 30s
+#
+trap stop_labkey SIGINT SIGTERM
+
+
+#
+# Monitor Tomcat process. If Tomcat stops running for
+# any reason, run the stop_labkey function to stop the container
+#
+TOMCAT_RUNNING=0
+PID=$(/bin/ps ax | grep bootstrap.jar | grep catalina)
+if [ -n "$PID" ]
+then
+    sleep 10
+    while [ ${TOMCAT_RUNNING} -eq 0 ]
+    do
+        PID=$(/bin/ps ax | grep bootstrap.jar | grep catalina)
+        if [ -n "$PID" ]
+        then
+            sleep 10
+            TOMCAT_RUNNING=0
+        else
+            TOMCAT_RUNNING=1
+            stop_labkey
+        fi
+    done
+else
+    TOMCAT_RUNNING=1
+    stop_labkey
+fi
+
+TOMCAT_RUNNING=1
+stop_labkey
+
+

--- a/docker/LabKeyServer/17.2/labkey/labkey.xml
+++ b/docker/LabKeyServer/17.2/labkey/labkey.xml
@@ -1,0 +1,52 @@
+<?xml version='1.0' encoding='utf-8'?>
+<Context docBase="/labkey/labkey/labkeywebapp" debug="0" reloadable="true" crossContext="true">
+
+<Resource name="jdbc/labkeyDataSource" auth="Container"
+        type="javax.sql.DataSource"
+        username="labkey"
+        password="@@PG_PASSWORD@@"
+        driverClassName="org.postgresql.Driver"
+        url="jdbc:postgresql://@@PG_HOST@@/labkey"
+        accessToUnderlyingConnectionAllowed="true"
+        initialSize="5"
+        maxActive="20"
+        maxIdle="5"
+        minIdle="4"
+        testOnBorrow="true"
+        testOnReturn="false"
+        testWhileIdle="true"
+        timeBetweenEvictionRunsMillis="60000"
+        minEvictableIdleTimeMillis="300000"
+        validationQuery="SELECT 1"
+        validationInterval="30000" />
+
+    <Resource name="mail/Session" auth="Container"
+        type="javax.mail.Session"
+        mail.smtp.host="localhost"
+        mail.smtp.user="anonymous"
+        mail.smtp.port="25"/>
+
+    <Loader loaderClass="org.labkey.bootstrap.LabkeyServerBootstrapClassLoader" />
+
+    <!-- Encryption key for encrypted property store -->
+    <Parameter name="MasterEncryptionKey" value="@@ENCRYPTION_KEY@@" />
+
+    <!-- mzML support via JNI -->
+    <!--
+        <Parameter name="org.labkey.api.ms2.mzmlLibrary" value="pwiz_swigbindings"></Parameter>
+         -->
+
+    <!-- Track installations from Windows Installer -->
+    <!--@@installer@@ <Parameter name="org.labkey.api.util.mothershipreport.usedInstaller" value="true"/> @@installer@@-->
+
+    <!-- Pipeline configuration -->
+    <!--@@pipeline@@    <Parameter name="org.labkey.api.pipeline.config" value="@@pipelineConfigPath@@"/> @@pipeline@@-->
+
+    <!--        brokerURL="tcp://localhost:61616" userName="username" password="password" -->
+    <!--@@jmsConfig@@ <Resource name="jms/ConnectionFactory" auth="Container"
+        type="org.apache.activemq.ActiveMQConnectionFactory"
+        factory="org.apache.activemq.jndi.JNDIReferenceFactory"
+        description="JMS Connection Factory"
+        brokerURL="vm://localhost?broker.persistent=false&amp;broker.useJmx=false"
+        brokerName="LocalActiveMQBroker"/> @@jmsConfig@@-->
+</Context>

--- a/docker/LabKeyServer/17.2/labkey/start_labkey.sh
+++ b/docker/LabKeyServer/17.2/labkey/start_labkey.sh
@@ -1,0 +1,140 @@
+#!/bin/bash
+#
+#
+# Copyright (c) 2016-2017 LabKey Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Start X Virtual Frame Buffer, PostgreSQL and Tomcat Services
+#
+# This entry point script will perform the following steps
+# 1) Read secrets
+#   - The required secrets are password for accessing LabKey database on PostgreSQL server
+#     and Master Encryption Key used to access LabKey PropertyStore
+#   - The secrets must be provided at RUN time using ENV variables
+#       * PG_PASSWORD
+#       * LABKEY_ENCRYPTION_KEY
+# 2) Start X virtual frame buffer (required for R reports)
+# 3) Start PostgreSQL Server and create "labkey" user
+# 4) Using secrets read above start Tomcat server
+#
+
+#
+# Read Secrets into variables to be used later in script
+#
+echo "Secrets: Reading secrets (ie passwords, etc) from environment"
+if [ -z "$PG_PASSWORD" ]
+then
+    echo "ERROR: PG_PASSWORD environment variable does not exist. This is required to start LabKey Server"
+    exit 1
+else
+    POSTGRESQL_PASSWORD="$PG_PASSWORD"
+fi
+
+if [ -z "$LABKEY_ENCRYPTION_KEY" ]
+then
+    echo "ERROR: LABKEY_ENCRYPTION_KEY environment variable does not exist. This is required to start LabKey Server"
+    exit 1
+else
+    MASTER_ENC_KEY="$LABKEY_ENCRYPTION_KEY"
+fi
+
+
+#
+# Start X Virtual Frame Buffer
+#
+
+echo "X VIRTUAL FRAME BUFFER: Starting Process "
+XVFB=/usr/bin/Xvfb
+XVFB_OPTIONS=":2 -nolisten tcp -shmem -extension GLX"
+$XVFB $XVFB_OPTIONS &
+RETVAL=$?
+sleep 2  # Added to ensure start-up is successful
+
+if [ $RETVAL -eq 0 ]
+then
+    echo "X VIRTUAL FRAME BUFFER started successfully"
+else
+    echo "X VIRTUAL FRAME BUFFER did not start properly"
+    exit 1
+fi
+
+#
+# Start PostgreSQL
+#
+echo "POSTGRESQL SERVER: Starting database server "
+INSTALLDIR=/labkey/apps/postgresql
+PGDATA=$INSTALLDIR/data
+BINDIR=$INSTALLDIR/bin
+
+if su - postgres -c "$BINDIR/pg_ctl -w start -D \"$PGDATA\"";
+then
+    echo "POSTGRESQL SERVER started successfully"
+else
+    echo "ERROR: POSTGRESQL SERVER did not start in a timely fashion"
+    exit 1
+fi
+
+# Create new user account on PostgreSQL server. Username=labkey
+if [ ! -f  /labkey/apps/postgresql/data/.LABKEY-ACCOUNT-CREATED ]
+then
+    if su - postgres -c "$BINDIR/psql --command \"CREATE USER labkey WITH SUPERUSER PASSWORD '$POSTGRESQL_PASSWORD';\""
+    then
+        echo "PostgreSQL user account successfully created"
+        touch /labkey/apps/postgresql/data/.LABKEY-ACCOUNT-CREATED
+    else
+        echo "ERROR: Failure during creation of PostgreSQL user account"
+        exit 1
+    fi
+fi
+
+
+#
+# Start Tomcat
+#
+
+# Customize configuration files using EVN variables
+echo "TOMCAT: Starting Tomcat Server to run LabKey Server application"
+INSTALLDIR=/labkey/apps/tomcat
+
+# Customize LabKey configuration file
+sed -i s/'@@PG_PASSWORD@@'/"$POSTGRESQL_PASSWORD"/g $INSTALLDIR/conf/Catalina/localhost/ROOT.xml
+sed -i s/'@@ENCRYPTION_KEY@@'/"$MASTER_ENC_KEY"/g $INSTALLDIR/conf/Catalina/localhost/ROOT.xml
+sed -i s/'@@PG_HOST@@'/"$PG_HOST"/g $INSTALLDIR/conf/Catalina/localhost/ROOT.xml
+
+if [ -f /labkey/apps/SSL/keystore.tomcat ]
+then
+    sed -i s/'@@KEYSTORE_PASSPHRASE@@'/"$KEYSTORE_PASSPHRASE"/g /labkey/apps/tomcat/conf/server.xml
+fi
+
+
+# Start Tomcat Server
+if ! /labkey/bin/start_tomcat.sh start
+then
+    echo "ERROR: TOMCAT did not start in a timely fashion"
+    exit 1
+fi
+
+echo "LabKey Server application has been successfully started"
+
+# Tomcat has started successfully. Now execute the CMD
+if [ "$1" = '/labkey/bin/check_labkey.sh' ]
+then
+    exec "$@"
+fi
+
+exec "$@"
+
+
+

--- a/docker/LabKeyServer/17.2/postgresql/pg_hba.conf
+++ b/docker/LabKeyServer/17.2/postgresql/pg_hba.conf
@@ -1,0 +1,8 @@
+# TYPE  DATABASE        USER            ADDRESS                 METHOD
+
+# "local" is for Unix domain socket connections only
+local   all             all                                     ident
+# IPv4 local connections:
+host    all             all             127.0.0.1/32            md5
+# IPv6 local connections:
+host    all             all             ::1/128                 md5

--- a/docker/LabKeyServer/17.2/postgresql/postgresql.conf
+++ b/docker/LabKeyServer/17.2/postgresql/postgresql.conf
@@ -1,0 +1,619 @@
+# -----------------------------
+# PostgreSQL configuration file
+# -----------------------------
+#
+# This file consists of lines of the form:
+#
+#   name = value
+#
+# (The "=" is optional.)  Whitespace may be used.  Comments are introduced with
+# "#" anywhere on a line.  The complete list of parameter names and allowed
+# values can be found in the PostgreSQL documentation.
+#
+# The commented-out settings shown in this file represent the default values.
+# Re-commenting a setting is NOT sufficient to revert it to the default value;
+# you need to reload the server.
+#
+# This file is read on server startup and when the server receives a SIGHUP
+# signal.  If you edit the file on a running system, you have to SIGHUP the
+# server for the changes to take effect, or use "pg_ctl reload".  Some
+# parameters, which are marked below, require a server shutdown and restart to
+# take effect.
+#
+# Any parameter can also be given as a command-line option to the server, e.g.,
+# "postgres -c log_connections=on".  Some parameters can be changed at run time
+# with the "SET" SQL command.
+#
+# Memory units:  kB = kilobytes        Time units:  ms  = milliseconds
+#                MB = megabytes                     s   = seconds
+#                GB = gigabytes                     min = minutes
+#                                                   h   = hours
+#                                                   d   = days
+
+
+#------------------------------------------------------------------------------
+# FILE LOCATIONS
+#------------------------------------------------------------------------------
+
+# The default values of these variables are driven from the -D command-line
+# option or PGDATA environment variable, represented here as ConfigDir.
+
+data_directory = '/labkey/apps/postgresql/data'     # use data in another directory
+                    # (change requires restart)
+hba_file = '/labkey/apps/postgresql/data/pg_hba.conf'  # host-based authentication file
+                    # (change requires restart)
+ident_file = '/labkey/apps/postgresql/data/pg_ident.conf'  # ident configuration file
+                    # (change requires restart)
+
+# If external_pid_file is not explicitly set, no extra PID file is written.
+#external_pid_file = ''         # write an extra PID file
+                    # (change requires restart)
+
+
+#------------------------------------------------------------------------------
+# CONNECTIONS AND AUTHENTICATION
+#------------------------------------------------------------------------------
+
+# - Connection Settings -
+
+listen_addresses = 'localhost'     # what IP address(es) to listen on;
+                    # comma-separated list of addresses;
+                    # defaults to 'localhost'; use '*' for all
+                    # (change requires restart)
+port = 5432            # (change requires restart)
+#max_connections = 100          # (change requires restart)
+# Note:  Increasing max_connections costs ~400 bytes of shared memory per
+# connection slot, plus lock space (see max_locks_per_transaction).
+#superuser_reserved_connections = 3 # (change requires restart)
+#unix_socket_directory = ''     # (change requires restart)
+#unix_socket_group = ''         # (change requires restart)
+#unix_socket_permissions = 0777     # begin with 0 to use octal notation
+                    # (change requires restart)
+#bonjour = off              # advertise server via Bonjour
+                    # (change requires restart)
+#bonjour_name = ''          # defaults to the computer name
+                    # (change requires restart)
+
+# - Security and Authentication -
+
+#authentication_timeout = 1min      # 1s-600s
+#ssl = off              # (change requires restart)
+#ssl_ciphers = 'ALL:!ADH:!LOW:!EXP:!MD5:@STRENGTH'  # allowed SSL ciphers
+                    # (change requires restart)
+#ssl_renegotiation_limit = 512MB    # amount of data between renegotiations
+#ssl_cert_file = 'server.crt'       # (change requires restart)
+#ssl_key_file = 'server.key'        # (change requires restart)
+#ssl_ca_file = ''           # (change requires restart)
+#ssl_crl_file = ''          # (change requires restart)
+#password_encryption = on
+#db_user_namespace = off
+
+# Kerberos and GSSAPI
+#krb_server_keyfile = ''
+#krb_srvname = 'postgres'       # (Kerberos only)
+#krb_caseins_users = off
+
+# - TCP Keepalives -
+# see "man 7 tcp" for details
+
+#tcp_keepalives_idle = 0        # TCP_KEEPIDLE, in seconds;
+                    # 0 selects the system default
+#tcp_keepalives_interval = 0        # TCP_KEEPINTVL, in seconds;
+                    # 0 selects the system default
+#tcp_keepalives_count = 0       # TCP_KEEPCNT;
+                    # 0 selects the system default
+
+
+#------------------------------------------------------------------------------
+# RESOURCE USAGE (except WAL)
+#------------------------------------------------------------------------------
+
+# - Memory -
+
+shared_buffers = 512MB            # min 128kB
+                    # (change requires restart)
+
+#huge_pages = try                       # on, off, or try
+                                        # (change requires restart)
+#temp_buffers = 8MB         # min 800kB
+#max_prepared_transactions = 0          # zero disables the feature
+                                        # (change requires restart)
+# Note:  Increasing max_prepared_transactions costs ~600 bytes of shared memory
+# per transaction slot, plus lock space (see max_locks_per_transaction).
+# It is not advisable to set max_prepared_transactions nonzero unless you
+# actively intend to use prepared transactions.
+work_mem = 10MB                # min 64kB
+maintenance_work_mem = 1024MB      # min 1MB
+#max_stack_depth = 2MB          # min 100kB
+#dynamic_shared_memory_type = posix     # the default is the first option
+                                        # supported by the operating system:
+                                        #   posix
+                                        #   sysv
+                                        #   windows
+                                        #   mmap
+                                        # use none to disable dynamic shared memory
+
+# - Disk -
+
+#temp_file_limit = -1           # limits per-session temp file space
+                    # in kB, or -1 for no limit
+
+# - Kernel Resource Usage -
+
+#max_files_per_process = 1000       # min 25
+                    # (change requires restart)
+#shared_preload_libraries = ''      # (change requires restart)
+
+# - Cost-Based Vacuum Delay -
+
+#vacuum_cost_delay = 0ms        # 0-100 milliseconds
+#vacuum_cost_page_hit = 1       # 0-10000 credits
+#vacuum_cost_page_miss = 10     # 0-10000 credits
+#vacuum_cost_page_dirty = 20        # 0-10000 credits
+#vacuum_cost_limit = 200        # 1-10000 credits
+
+# - Background Writer -
+
+#bgwriter_delay = 200ms         # 10-10000ms between rounds
+#bgwriter_lru_maxpages = 100        # 0-1000 max buffers written/round
+#bgwriter_lru_multiplier = 2.0      # 0-10.0 multipler on buffers scanned/round
+
+# - Asynchronous Behavior -
+
+#effective_io_concurrency = 1       # 1-1000; 0 disables prefetching
+#max_worker_processes = 8
+
+
+#------------------------------------------------------------------------------
+# WRITE AHEAD LOG
+#------------------------------------------------------------------------------
+
+# - Settings -
+
+#wal_level = minimal               # minimal, archive, or hot_standby
+                    # (change requires restart)
+#fsync = on             # turns forced synchronization on or off
+#synchronous_commit = on           # synchronization level;
+                    # off, local, remote_write, or on
+#wal_sync_method = fsync           # the default is the first option
+                                   # supported by the operating system:
+                                   #   open_datasync
+                                   #   fdatasync (default on Linux)
+                                   #   fsync
+                                   #   fsync_writethrough
+                                   #   open_sync
+#full_page_writes = on             # recover from partial page writes
+#wal_compression = off             # enable compression of full-page writes
+#wal_log_hints = off               # also do full page writes of non-critical updates
+                                   # (change requires restart)
+wal_buffers = -1                   # min 32kB, -1 sets based on shared_buffers
+                                   # (change requires restart)
+#wal_writer_delay = 200ms          # 1-10000 milliseconds
+
+#commit_delay = 0                  # range 0-100000, in microseconds
+#commit_siblings = 5               # range 1-1000
+
+# - Checkpoints -
+
+checkpoint_timeout = 15min        # range 30s-1h
+#max_wal_size = 1GB
+#min_wal_size = 80MB
+#checkpoint_completion_target = 0.5 # checkpoint target duration, 0.0 - 1.0
+#checkpoint_warning = 30s          # 0 disables
+
+# - Archiving -
+
+#archive_mode = off                # allows archiving to be done
+                                   # (change requires restart)
+#archive_command = ''              # command to use to archive a logfile segment
+                                   # placeholders: %p = path of file to archive
+                                   #               %f = file name only
+                                   # e.g. 'test ! -f /mnt/server/archivedir/%f && cp %p /mnt/server/archivedir/%f'
+#archive_timeout = 0               # force a logfile segment switch after this
+                                   # number of seconds; 0 disables
+
+
+#------------------------------------------------------------------------------
+# REPLICATION
+#------------------------------------------------------------------------------
+
+# - Sending Server(s) -
+
+# Set these on the master and on any standby that will send replication data.
+
+#max_wal_senders = 0        # max number of walsender processes
+                # (change requires restart)
+#wal_keep_segments = 0      # in logfile segments, 16MB each; 0 disables
+#replication_timeout = 60s  # in milliseconds; 0 disables
+
+# - Master Server -
+
+# These settings are ignored on a standby server.
+
+#synchronous_standby_names = '' # standby servers that provide sync rep
+                # comma-separated list of application_name
+                # from standby(s); '*' = all
+#vacuum_defer_cleanup_age = 0   # number of xacts by which cleanup is delayed
+
+# - Standby Servers -
+
+# These settings are ignored on a master server.
+
+#hot_standby = off          # "on" allows queries during recovery
+                    # (change requires restart)
+#max_standby_archive_delay = 30s    # max delay before canceling queries
+                    # when reading WAL from archive;
+                    # -1 allows indefinite delay
+#max_standby_streaming_delay = 30s  # max delay before canceling queries
+                    # when reading streaming WAL;
+                    # -1 allows indefinite delay
+#wal_receiver_status_interval = 10s # send replies at least this often
+                    # 0 disables
+#hot_standby_feedback = off     # send info from standby to prevent
+                    # query conflicts
+
+
+#------------------------------------------------------------------------------
+# QUERY TUNING
+#------------------------------------------------------------------------------
+
+# - Planner Method Configuration -
+
+#enable_bitmapscan = on
+#enable_hashagg = on
+#enable_hashjoin = on
+#enable_indexscan = on
+#enable_indexonlyscan = on
+#enable_material = on
+#enable_mergejoin = on
+#enable_nestloop = on
+#enable_seqscan = on
+#enable_sort = on
+#enable_tidscan = on
+
+# - Planner Cost Constants -
+
+#seq_page_cost = 1.0            # measured on an arbitrary scale
+random_page_cost = 1.4            # same scale as above
+#cpu_tuple_cost = 0.01          # same scale as above
+#cpu_index_tuple_cost = 0.005       # same scale as above
+#cpu_operator_cost = 0.0025     # same scale as above
+effective_cache_size = 1024MB
+
+# - Genetic Query Optimizer -
+
+#geqo = on
+#geqo_threshold = 12
+#geqo_effort = 5            # range 1-10
+#geqo_pool_size = 0         # selects default based on effort
+#geqo_generations = 0           # selects default based on effort
+#geqo_selection_bias = 2.0      # range 1.5-2.0
+#geqo_seed = 0.0            # range 0.0-1.0
+
+# - Other Planner Options -
+
+#default_statistics_target = 100        # range 1-10000
+#constraint_exclusion = partition       # on, off, or partition
+#cursor_tuple_fraction = 0.1            # range 0.0-1.0
+#from_collapse_limit = 8
+join_collapse_limit = 10                # 1 disables collapsing of explicit
+                                        # JOIN clauses
+
+
+#------------------------------------------------------------------------------
+# ERROR REPORTING AND LOGGING
+#------------------------------------------------------------------------------
+
+# - Where to Log -
+
+#log_destination = 'stderr'             # Valid values are combinations of
+                                        # stderr, csvlog, syslog, and eventlog,
+                                        # depending on platform.  csvlog
+                                        # requires logging_collector to be on.
+
+# This is used when logging to stderr:
+logging_collector = on                  # Enable capturing of stderr and csvlog
+                                        # into log files. Required to be on for
+                                        # csvlogs.
+                                        # (change requires restart)
+
+# These are only used if logging_collector is on:
+log_directory = 'pg_log'                # directory where log files are written,
+                                        # can be absolute or relative to PGDATA
+log_filename = 'postgresql-%Y-%m-%d_%H%M%S.log' # log file name pattern,
+                                        # can include strftime() escapes
+#log_file_mode = 0600                   # creation mode for log files,
+                                        # begin with 0 to use octal notation
+#log_truncate_on_rotation = off         # If on, an existing log file with the
+                                        # same name as the new log file will be
+                                        # truncated rather than appended to.
+                                        # But such truncation only occurs on
+                                        # time-driven rotation, not on restarts
+                                        # or size-driven rotation.  Default is
+                                        # off, meaning append to existing files
+                                        # in all cases.
+log_rotation_age = 1d                   # Automatic rotation of logfiles will
+                                        # happen after that time.  0 disables.
+#log_rotation_size = 10MB               # Automatic rotation of logfiles will
+                                        # happen after that much log output.
+                                        # 0 disables.
+
+# These are relevant when logging to syslog:
+#syslog_facility = 'LOCAL0'
+#syslog_ident = 'postgres'
+
+# This is only relevant when logging to eventlog (win32):
+#event_source = 'PostgreSQL'
+
+# - When to Log -
+
+#client_min_messages = notice       # values in order of decreasing detail:
+                    #   debug5
+                    #   debug4
+                    #   debug3
+                    #   debug2
+                    #   debug1
+                    #   log
+                    #   notice
+                    #   warning
+                    #   error
+
+#log_min_messages = warning     # values in order of decreasing detail:
+                    #   debug5
+                    #   debug4
+                    #   debug3
+                    #   debug2
+                    #   debug1
+                    #   info
+                    #   notice
+                    #   warning
+                    #   error
+                    #   log
+                    #   fatal
+                    #   panic
+
+#log_min_error_statement = error    # values in order of decreasing detail:
+                    #   debug5
+                    #   debug4
+                    #   debug3
+                    #   debug2
+                    #   debug1
+                    #   info
+                    #   notice
+                    #   warning
+                    #   error
+                    #   log
+                    #   fatal
+                    #   panic (effectively off)
+
+#log_min_duration_statement = -1    # -1 is disabled, 0 logs all statements
+                    # and their durations, > 0 logs only
+                    # statements running at least this number
+                    # of milliseconds
+
+
+# - What to Log -
+
+#debug_print_parse = off
+#debug_print_rewritten = off
+#debug_print_plan = off
+#debug_pretty_print = on
+log_checkpoints = on
+log_connections = on
+log_disconnections = on
+#log_duration = off
+#log_error_verbosity = default               # terse, default, or verbose messages
+#log_hostname = off
+log_line_prefix = '%m %p %u %d %h'           # special values:
+                                             #   %a = application name
+                                             #   %u = user name
+                                             #   %d = database name
+                                             #   %r = remote host and port
+                                             #   %h = remote host
+                                             #   %p = process ID
+                                             #   %t = timestamp without milliseconds
+                                             #   %m = timestamp with milliseconds
+                                             #   %i = command tag
+                                             #   %e = SQL state
+                                             #   %c = session ID
+                                             #   %l = session line number
+                                             #   %s = session start timestamp
+                                             #   %v = virtual transaction ID
+                                             #   %x = transaction ID (0 if none)
+                                             #   %q = stop here in non-session
+                                             #        processes
+                                             #   %% = '%'
+                                             # e.g. '<%u%%%d> '
+
+log_lock_waits = on                          # log lock waits >= deadlock_timeout
+#log_statement = 'none'                      # none, ddl, mod, all
+#log_temp_files = -1                         # log temporary files equal or larger
+                                             # than the specified size in kilobytes;
+                                             # -1 disables, 0 logs all temp files
+#log_timezone = 'GMT'
+
+
+# - Process Title -
+
+#cluster_name = ''                           # added to process titles if nonempty
+                                             # (change requires restart)
+#update_process_title = on
+
+
+
+#------------------------------------------------------------------------------
+# RUNTIME STATISTICS
+#------------------------------------------------------------------------------
+
+# - Query/Index Statistics Collector -
+
+#track_activities = on
+#track_counts = on
+#track_io_timing = off
+#track_functions = none                 # none, pl, all
+#track_activity_query_size = 1024       # (change requires restart)
+#stats_temp_directory = 'pg_stat_tmp'
+
+
+# - Statistics Monitoring -
+
+#log_parser_stats = off
+#log_planner_stats = off
+#log_executor_stats = off
+#log_statement_stats = off
+
+
+#------------------------------------------------------------------------------
+# AUTOVACUUM PARAMETERS
+#------------------------------------------------------------------------------
+
+#autovacuum = on                        # Enable autovacuum subprocess?  'on'
+                                        # requires track_counts to also be on.
+#log_autovacuum_min_duration = -1       # -1 disables, 0 logs all actions and
+                                        # their durations, > 0 logs only
+                                        # actions running at least this number
+                                        # of milliseconds.
+#autovacuum_max_workers = 3             # max number of autovacuum subprocesses
+                                        # (change requires restart)
+#autovacuum_naptime = 1min              # time between autovacuum runs
+#autovacuum_vacuum_threshold = 50       # min number of row updates before
+                                        # vacuum
+#autovacuum_analyze_threshold = 50      # min number of row updates before
+                                        # analyze
+#autovacuum_vacuum_scale_factor = 0.2   # fraction of table size before vacuum
+#autovacuum_analyze_scale_factor = 0.1  # fraction of table size before analyze
+#autovacuum_freeze_max_age = 200000000  # maximum XID age before forced vacuum
+                                        # (change requires restart)
+#autovacuum_multixact_freeze_max_age = 400000000        # maximum multixact age
+                                        # before forced vacuum
+                                        # (change requires restart)
+#autovacuum_vacuum_cost_delay = 20ms    # default vacuum cost delay for
+                                        # autovacuum, in milliseconds;
+                                        # -1 means use vacuum_cost_delay
+#autovacuum_vacuum_cost_limit = -1      # default vacuum cost limit for
+                                        # autovacuum, -1 means use
+                                        # vacuum_cost_limit
+
+
+#------------------------------------------------------------------------------
+# CLIENT CONNECTION DEFAULTS
+#------------------------------------------------------------------------------
+
+# - Statement Behavior -
+
+#search_path = '"$user", public'        # schema names
+#default_tablespace = ''                # a tablespace name, '' uses the default
+#temp_tablespaces = ''                  # a list of tablespace names, '' uses
+                                        # only default tablespace
+#check_function_bodies = on
+#default_transaction_isolation = 'read committed'
+#default_transaction_read_only = off
+#default_transaction_deferrable = off
+#session_replication_role = 'origin'
+#statement_timeout = 0                  # in milliseconds, 0 is disabled
+#lock_timeout = 0                       # in milliseconds, 0 is disabled
+#vacuum_freeze_min_age = 50000000
+#vacuum_freeze_table_age = 150000000
+#vacuum_multixact_freeze_min_age = 5000000
+#vacuum_multixact_freeze_table_age = 150000000
+#bytea_output = 'hex'                   # hex, escape
+#xmlbinary = 'base64'
+#xmloption = 'content'
+#gin_fuzzy_search_limit = 0
+#gin_pending_list_limit = 4MB
+
+# - Locale and Formatting -
+
+#datestyle = 'iso, mdy'
+#intervalstyle = 'postgres'
+#timezone = 'GMT'
+#timezone_abbreviations = 'Default'     # Select the set of available time zone
+                                        # abbreviations.  Currently, there are
+                                        #   Default
+                                        #   Australia (historical usage)
+                                        #   India
+                                        # You can create your own file in
+                                        # share/timezonesets/.
+#extra_float_digits = 0                 # min -15, max 3
+#client_encoding = sql_ascii            # actually, defaults to database
+                                        # encoding
+
+# These settings are initialized by initdb, but they can be changed.
+#lc_messages = 'C'                      # locale for system error message
+                                        # strings
+#lc_monetary = 'C'                      # locale for monetary formatting
+#lc_numeric = 'C'                       # locale for number formatting
+#lc_time = 'C'                          # locale for time formatting
+
+# default configuration for text search
+#default_text_search_config = 'pg_catalog.simple'
+
+# - Other Defaults -
+
+#dynamic_library_path = '$libdir'
+#local_preload_libraries = ''
+#session_preload_libraries = ''
+
+
+#------------------------------------------------------------------------------
+# LOCK MANAGEMENT
+#------------------------------------------------------------------------------
+
+#deadlock_timeout = 1s
+#max_locks_per_transaction = 64         # min 10
+                                        # (change requires restart)
+# Note:  Each lock table slot uses ~270 bytes of shared memory, and there are
+# max_locks_per_transaction * (max_connections + max_prepared_transactions)
+# lock table slots.
+#max_pred_locks_per_transaction = 64    # min 10
+                                        # (change requires restart)
+
+
+#------------------------------------------------------------------------------
+# VERSION/PLATFORM COMPATIBILITY
+#------------------------------------------------------------------------------
+
+# - Previous PostgreSQL Versions -
+
+#array_nulls = on
+#backslash_quote = safe_encoding        # on, off, or safe_encoding
+#default_with_oids = off
+#escape_string_warning = on
+#lo_compat_privileges = off
+#operator_precedence_warning = off
+#quote_all_identifiers = off
+#sql_inheritance = on
+#standard_conforming_strings = on
+#synchronize_seqscans = on
+
+# - Other Platforms and Clients -
+
+#transform_null_equals = off
+
+
+#------------------------------------------------------------------------------
+# ERROR HANDLING
+#------------------------------------------------------------------------------
+
+#exit_on_error = off                    # terminate session on any error?
+#restart_after_crash = on               # reinitialize after backend crash?
+
+
+#------------------------------------------------------------------------------
+# CONFIG FILE INCLUDES
+#------------------------------------------------------------------------------
+
+# These options allow settings to be loaded from files other than the
+# default postgresql.conf.
+
+#include_dir = 'conf.d'                 # include files ending in '.conf' from
+                                        # directory 'conf.d'
+#include_if_exists = 'exists.conf'      # include file only if it exists
+#include = 'special.conf'               # include file
+
+
+#------------------------------------------------------------------------------
+# CUSTOMIZED OPTIONS
+#------------------------------------------------------------------------------
+
+# Add settings for extensions here

--- a/docker/LabKeyServer/17.2/tomcat/server-ssl.xml
+++ b/docker/LabKeyServer/17.2/tomcat/server-ssl.xml
@@ -1,0 +1,135 @@
+<?xml version='1.0' encoding='utf-8'?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<!-- Note:  A "Server" is not itself a "Container", so you may not
+     define subcomponents such as "Valves" at this level.
+     Documentation at /docs/config/server.html
+ -->
+<Server port="8005" shutdown="SHUTDOWN">
+  <!--APR library loader. Documentation at /docs/apr.html -->
+  <!-- Disable APR Listener as we do not want it to be used on
+       Tomcat server running LabKey Server
+  <Listener className="org.apache.catalina.core.AprLifecycleListener" SSLEngine="on" />
+  -->
+  <Listener className="org.apache.catalina.startup.VersionLoggerListener" />
+  <!-- Security listener. Documentation at /docs/config/listeners.html
+  <Listener className="org.apache.catalina.security.SecurityListener" />
+  -->
+
+  <!-- Prevent memory leaks due to use of particular java/javax APIs-->
+  <Listener className="org.apache.catalina.core.JreMemoryLeakPreventionListener" />
+  <Listener className="org.apache.catalina.mbeans.GlobalResourcesLifecycleListener" />
+  <Listener className="org.apache.catalina.core.ThreadLocalLeakPreventionListener" />
+
+  <!-- Global JNDI resources
+       Documentation at /docs/jndi-resources-howto.html
+  -->
+  <GlobalNamingResources>
+    <!-- Editable user database that can also be used by
+         UserDatabaseRealm to authenticate users
+    -->
+    <Resource name="UserDatabase" auth="Container"
+              type="org.apache.catalina.UserDatabase"
+              description="User database that can be updated and saved"
+              factory="org.apache.catalina.users.MemoryUserDatabaseFactory"
+              pathname="conf/tomcat-users.xml" />
+  </GlobalNamingResources>
+
+  <!-- A "Service" is a collection of one or more "Connectors" that share
+       a single "Container" Note:  A "Service" is not itself a "Container",
+       so you may not define subcomponents such as "Valves" at this level.
+       Documentation at /docs/config/service.html
+   -->
+  <Service name="Catalina">
+
+    <!--The connectors will use a shared executor, you can define one or
+        more named thread pools. For LabKey Server, a single shared pool
+        will be used for all connectors.
+    -->
+    <Executor name="tomcatSharedThreadPool" namePrefix="catalina-exec-"
+        maxThreads="300" minSpareThreads="25" maxIdleTime="20000"/>
+
+    <!-- Define HTTP connector -->
+    <Connector port="8080" redirectPort="8443" scheme="http"
+        protocol="org.apache.coyote.http11.Http11Protocol"
+        executor="tomcatSharedThreadPool"
+        acceptCount="100" connectionTimeout="20000"
+        disableUploadTimeout="true" enableLookups="false"
+        maxHttpHeaderSize="8192" minSpareThreads="25"
+        useBodyEncodingForURI="true" URIEncoding="UTF-8"
+        compression="on" compressionMinSize="2048"
+        noCompressionUserAgents="gozilla, traviata"
+        compressableMimeType="text/html,text/xml,text/css,application/json"/>
+
+    <!-- Define HTTPS connector. -->
+    <Connector port="8443" scheme="https" secure="true"
+        SSLEnabled="true" sslEnabledProtocols="TLSv1,TLSv1.1,TLSv1.2" sslProtocol="TLSv1"
+        ciphers="TLS_DHE_RSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384, TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384,  TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA, TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA, TLS_ECDH_RSA_WITH_AES_256_GCM_SHA384, TLS_ECDH_ECDSA_WITH_AES_256_GCM_SHA384, TLS_ECDH_RSA_WITH_AES_256_CBC_SHA384, TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA384, TLS_ECDH_RSA_WITH_AES_256_CBC_SHA, TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA, TLS_DHE_RSA_WITH_AES_256_CBC_SHA256, TLS_DHE_RSA_WITH_AES_256_CBC_SHA, TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256, TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256, TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256, TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA, TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA, TLS_ECDH_RSA_WITH_AES_128_GCM_SHA256, TLS_ECDH_ECDSA_WITH_AES_128_GCM_SHA256, TLS_ECDH_RSA_WITH_AES_128_CBC_SHA256, TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA256, TLS_ECDH_RSA_WITH_AES_128_CBC_SHA, TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA, TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA, TLS_ECDHE_ECDSA_WITH_3DES_EDE_CBC_SHA, TLS_ECDH_RSA_WITH_3DES_EDE_CBC_SHA, TLS_ECDH_ECDSA_WITH_3DES_EDE_CBC_SHA, TLS_DHE_RSA_WITH_3DES_EDE_CBC_SHA, TLS_RSA_WITH_AES_256_GCM_SHA384, TLS_RSA_WITH_AES_128_GCM_SHA256, TLS_RSA_WITH_AES_256_CBC_SHA256, TLS_RSA_WITH_AES_256_CBC_SHA, TLS_RSA_WITH_AES_128_CBC_SHA256, TLS_RSA_WITH_AES_128_CBC_SHA, TLS_RSA_WITH_3DES_EDE_CBC_SHA"
+        protocol="org.apache.coyote.http11.Http11Protocol"
+        executor="tomcatSharedThreadPool"
+        acceptCount="100" connectionTimeout="20000"
+        clientAuth="false" disableUploadTimeout="true" enableLookups="false"
+        maxHttpHeaderSize="8192" minSpareThreads="25"
+        useBodyEncodingForURI="true" URIEncoding="UTF-8"
+        compression="on" compressionMinSize="2048"
+        noCompressionUserAgents="gozilla, traviata"
+        compressableMimeType="text/html,text/xml,text/css,application/json"
+        keystoreType="pkcs12" keystorePass="@@KEYSTORE_PASSPHRASE@@"
+        keystoreFile="/labkey/apps/SSL/keystore.tomcat" />
+
+    <!-- Define an AJP 1.3 Connector on port 8009 -->
+    <!-- Disable AJP
+    <Connector port="8009" protocol="AJP/1.3" redirectPort="8443" />
+    -->
+
+    <!-- An Engine represents the entry point (within Catalina) that processes
+         every request.  The Engine implementation for Tomcat stand alone
+         analyzes the HTTP headers included with the request, and passes them
+         on to the appropriate Host (virtual host).
+         Documentation at /docs/config/engine.html
+    -->
+
+    <Engine name="Catalina" defaultHost="localhost">
+
+      <!-- Use the LockOutRealm to prevent attempts to guess user passwords
+           via a brute-force attack -->
+      <Realm className="org.apache.catalina.realm.LockOutRealm">
+        <!-- This Realm uses the UserDatabase configured in the global JNDI
+             resources under the key "UserDatabase".  Any edits
+             that are performed against this UserDatabase are immediately
+             available for use by the Realm.  -->
+        <Realm className="org.apache.catalina.realm.UserDatabaseRealm" resourceName="UserDatabase"/>
+      </Realm>
+
+      <Host name="localhost"  appBase="webapps"
+            unpackWARs="true" autoDeploy="true">
+
+        <!-- Access log processes all example.
+             Documentation at: /docs/config/valve.html
+             Note: The pattern used is equivalent to using pattern="common" -->
+        <Valve className="org.apache.catalina.valves.AccessLogValve"
+            directory="logs"
+            prefix="localhost_access_log"
+            suffix=".txt"
+            resolveHosts="false"
+            pattern="%h %l %u %t &quot;%r&quot; %s %b %D %S &quot;%{Referer}i&quot; &quot;%{User-Agent}i&quot; %{LABKEY.username}s %q" />
+
+      </Host>
+    </Engine>
+  </Service>
+</Server>
+

--- a/docker/LabKeyServer/17.2/tomcat/server.xml
+++ b/docker/LabKeyServer/17.2/tomcat/server.xml
@@ -1,0 +1,120 @@
+<?xml version='1.0' encoding='utf-8'?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<!-- Note:  A "Server" is not itself a "Container", so you may not
+     define subcomponents such as "Valves" at this level.
+     Documentation at /docs/config/server.html
+ -->
+<Server port="8005" shutdown="SHUTDOWN">
+  <!--APR library loader. Documentation at /docs/apr.html -->
+  <!-- Disable APR Listener as we do not want it to be used on
+       Tomcat server running LabKey Server
+  <Listener className="org.apache.catalina.core.AprLifecycleListener" SSLEngine="on" />
+  -->
+
+  <Listener className="org.apache.catalina.startup.VersionLoggerListener" />
+  <!-- Security listener. Documentation at /docs/config/listeners.html
+  <Listener className="org.apache.catalina.security.SecurityListener" />
+  -->
+
+  <!-- Prevent memory leaks due to use of particular java/javax APIs-->
+  <Listener className="org.apache.catalina.core.JreMemoryLeakPreventionListener" />
+  <Listener className="org.apache.catalina.mbeans.GlobalResourcesLifecycleListener" />
+  <Listener className="org.apache.catalina.core.ThreadLocalLeakPreventionListener" />
+
+  <!-- Global JNDI resources
+       Documentation at /docs/jndi-resources-howto.html
+  -->
+  <GlobalNamingResources>
+    <!-- Editable user database that can also be used by
+         UserDatabaseRealm to authenticate users
+    -->
+    <Resource name="UserDatabase" auth="Container"
+              type="org.apache.catalina.UserDatabase"
+              description="User database that can be updated and saved"
+              factory="org.apache.catalina.users.MemoryUserDatabaseFactory"
+              pathname="conf/tomcat-users.xml" />
+  </GlobalNamingResources>
+
+  <!-- A "Service" is a collection of one or more "Connectors" that share
+       a single "Container" Note:  A "Service" is not itself a "Container",
+       so you may not define subcomponents such as "Valves" at this level.
+       Documentation at /docs/config/service.html
+   -->
+  <Service name="Catalina">
+
+    <!--The connectors will use a shared executor, you can define one or
+        more named thread pools. For LabKey Server, a single shared pool
+        will be used for all connectors.
+    -->
+    <Executor name="tomcatSharedThreadPool" namePrefix="catalina-exec-"
+        maxThreads="300" minSpareThreads="25" maxIdleTime="20000"/>
+
+    <!-- Define HTTP connector -->
+    <Connector port="8080" redirectPort="443" scheme="http"
+        protocol="org.apache.coyote.http11.Http11Protocol"
+        executor="tomcatSharedThreadPool"
+        acceptCount="100" connectionTimeout="20000"
+        disableUploadTimeout="true" enableLookups="false"
+        maxHttpHeaderSize="8192" minSpareThreads="25"
+        useBodyEncodingForURI="true" URIEncoding="UTF-8"
+        compression="on" compressionMinSize="2048"
+        noCompressionUserAgents="gozilla, traviata"
+        compressableMimeType="text/html,text/xml,text/css,application/json"/>
+
+
+    <!-- Define an AJP 1.3 Connector on port 8009 -->
+    <!-- Disable AJP
+    <Connector port="8009" protocol="AJP/1.3" redirectPort="8443" />
+    -->
+
+    <!-- An Engine represents the entry point (within Catalina) that processes
+         every request.  The Engine implementation for Tomcat stand alone
+         analyzes the HTTP headers included with the request, and passes them
+         on to the appropriate Host (virtual host).
+         Documentation at /docs/config/engine.html
+    -->
+
+    <Engine name="Catalina" defaultHost="localhost">
+
+      <!-- Use the LockOutRealm to prevent attempts to guess user passwords
+           via a brute-force attack -->
+      <Realm className="org.apache.catalina.realm.LockOutRealm">
+        <!-- This Realm uses the UserDatabase configured in the global JNDI
+             resources under the key "UserDatabase".  Any edits
+             that are performed against this UserDatabase are immediately
+             available for use by the Realm.  -->
+        <Realm className="org.apache.catalina.realm.UserDatabaseRealm" resourceName="UserDatabase"/>
+      </Realm>
+
+      <Host name="localhost"  appBase="webapps"
+            unpackWARs="true" autoDeploy="true">
+
+        <!-- Access log processes all example.
+             Documentation at: /docs/config/valve.html
+             Note: The pattern used is equivalent to using pattern="common" -->
+        <Valve className="org.apache.catalina.valves.AccessLogValve"
+            directory="logs"
+            prefix="localhost_access_log."
+            suffix=".txt"
+            resolveHosts="false"
+            pattern="%h %l %u %t &quot;%r&quot; %s %b %D %S &quot;%{Referer}i&quot; &quot;%{User-Agent}i&quot; %{LABKEY.username}s %q" />
+
+      </Host>
+    </Engine>
+  </Service>
+</Server>

--- a/docker/LabKeyServer/17.2/tomcat/start_tomcat.sh
+++ b/docker/LabKeyServer/17.2/tomcat/start_tomcat.sh
@@ -1,0 +1,209 @@
+#!/bin/sh
+#
+# Written by Miquel van Smoorenburg <miquels@cistron.nl>.
+# Modified for Debian GNU/Linux by Ian Murdock <imurdock@gnu.ai.mit.edu>.
+# Modified for Tomcat by Stefan Gybas <sgybas@debian.org>.
+# Modified for Tomcat6 by Thierry Carrez <thierry.carrez@ubuntu.com>.
+# Modified for Tomcat7 by Ernesto Hernandez-Novich <emhn@itverx.com.ve>.
+# Additional improvements by Jason Brittain <jason.brittain@mulesoft.com>.
+#
+# Modified by Brian Connolly at LabKey for use with LabKey Servers running in
+# docker containers
+#
+
+set -e
+
+#
+# Set variables
+#
+PATH=/bin:/usr/bin:/sbin:/usr/sbin
+NAME=tomcat
+DESC="Tomcat servlet engine"
+CATALINA_HOME=/labkey/apps/tomcat
+CATALINA_BASE=$CATALINA_HOME
+JAVA_OPTS="-Djava.awt.headless=true -Duser.timezone=America/Los_Angeles -Xms256M -Xmx2048M -Djava.net.preferIPv4Stack=true"
+JVM_TMP=$CATALINA_HOME/temp
+JAVA_HOME=/labkey/apps/java
+
+# Run Tomcat as this user ID and group ID
+TOMCAT_USER=tomcat
+TOMCAT_GROUP=tomcat
+
+# Use the Java security manager? (yes/no)
+TOMCAT_SECURITY=no
+
+export JAVA_HOME
+
+if [ `id -u` -ne 0 ]; then
+    echo "You need root privileges to run this script"
+    exit 1
+fi
+
+
+
+. /lib/lsb/init-functions
+
+
+# Default Java options
+# Set java.awt.headless=true if JAVA_OPTS is not set so the
+# Xalan XSL transformer can work without X11 display on JDK 1.4+
+# It also looks like the default heap size of 64M is not enough for most cases
+# so the maximum heap size is set to 128M
+if [ -z "$JAVA_OPTS" ]; then
+    JAVA_OPTS="-Djava.awt.headless=true -Xmx128M"
+fi
+
+if [ ! -f "$CATALINA_HOME/bin/bootstrap.jar" ]; then
+    log_failure_msg "$NAME is not installed"
+    exit 1
+fi
+
+if [ -z "$CATALINA_TMPDIR" ]; then
+    CATALINA_TMPDIR="$JVM_TMP"
+fi
+
+SECURITY=""
+if [ "$TOMCAT_SECURITY" = "yes" ]; then
+    SECURITY="-security"
+fi
+
+# Define other required variables
+CATALINA_PID="/var/run/$NAME.pid"
+CATALINA_SH="$CATALINA_HOME/bin/catalina.sh"
+
+# Look for Java Secure Sockets Extension (JSSE) JARs
+if [ -z "${JSSE_HOME}" -a -r "${JAVA_HOME}/jre/lib/jsse.jar" ]; then
+    JSSE_HOME="${JAVA_HOME}/jre/"
+fi
+
+catalina_sh() {
+    # Escape any double quotes in the value of JAVA_OPTS
+    JAVA_OPTS="$(echo $JAVA_OPTS | sed 's/\"/\\\"/g')"
+
+    AUTHBIND_COMMAND=""
+    if [ "$AUTHBIND" = "yes" -a "$1" = "start" ]; then
+        AUTHBIND_COMMAND="/usr/bin/authbind --deep /bin/bash -c "
+    fi
+
+    # Define the command to run Tomcat's catalina.sh as a daemon
+    # set -a tells sh to export assigned variables to spawned shells.
+    TOMCAT_SH="set -a; JAVA_HOME=\"$JAVA_HOME\"; source \"$DEFAULT\"; \
+        CATALINA_HOME=\"$CATALINA_HOME\"; \
+        CATALINA_BASE=\"$CATALINA_BASE\"; \
+        JAVA_OPTS=\"$JAVA_OPTS\"; \
+        CATALINA_PID=\"$CATALINA_PID\"; \
+        CATALINA_TMPDIR=\"$CATALINA_TMPDIR\"; \
+        LANG=\"$LANG\"; JSSE_HOME=\"$JSSE_HOME\"; \
+        cd \"$CATALINA_BASE\"; \
+        \"$CATALINA_SH\" $@"
+
+    if [ "$AUTHBIND" = "yes" -a "$1" = "start" ]; then
+        TOMCAT_SH="'$TOMCAT_SH'"
+    fi
+
+    # Run the catalina.sh script as a daemon
+    set +e
+    touch "$CATALINA_PID" "$CATALINA_BASE"/logs/catalina.out
+    chown $TOMCAT_USER "$CATALINA_PID" "$CATALINA_BASE"/logs/catalina.out
+    start-stop-daemon --start -b -u "$TOMCAT_USER" -g "$TOMCAT_GROUP" \
+        -c "$TOMCAT_USER" -d "$CATALINA_TMPDIR" -p "$CATALINA_PID" \
+        -x /bin/bash -- -c "$AUTHBIND_COMMAND $TOMCAT_SH"
+    status="$?"
+    set +a -e
+    return $status
+}
+
+case "$1" in
+  start)
+    if [ -z "$JAVA_HOME" ]; then
+        log_failure_msg "no JDK or JRE found - please set JAVA_HOME"
+        exit 1
+    fi
+
+    if [ ! -d "$CATALINA_BASE/conf" ]; then
+        log_failure_msg "invalid CATALINA_BASE: $CATALINA_BASE"
+        exit 1
+    fi
+
+    log_daemon_msg "Starting $DESC" "$NAME"
+    if start-stop-daemon --test --start --pidfile "$CATALINA_PID" \
+        --user $TOMCAT_USER --exec "$JAVA_HOME/bin/java" \
+        >/dev/null; then
+
+        catalina_sh start $SECURITY
+        if [ $? -eq 0 ]; then
+            log_end_msg 0
+        else
+            log_end_msg 1
+            if [ -f "$CATALINA_PID" ]; then
+                rm -f "$CATALINA_PID"
+            fi
+        fi
+        sleep 5
+    else
+        log_progress_msg "(already running)"
+        log_end_msg 0
+    fi
+    ;;
+  stop)
+    log_daemon_msg "Stopping $DESC" "$NAME"
+
+    set +e
+    if [ -f "$CATALINA_PID" ]; then
+        start-stop-daemon --stop --pidfile "$CATALINA_PID" \
+            --user "$TOMCAT_USER" \
+            --retry=TERM/20/KILL/5 >/dev/null
+        if [ $? -eq 1 ]; then
+            log_progress_msg "$DESC is not running but pid file exists, cleaning up"
+        elif [ $? -eq 3 ]; then
+            PID="`cat $CATALINA_PID`"
+            log_failure_msg "Failed to stop $NAME (pid $PID)"
+            exit 1
+        fi
+        rm -f "$CATALINA_PID"
+    else
+        log_progress_msg "(not running)"
+    fi
+    log_end_msg 0
+    set -e
+    ;;
+   status)
+    set +e
+    start-stop-daemon --test --start --pidfile "$CATALINA_PID" \
+        --user $TOMCAT_USER --exec "$JAVA_HOME/bin/java" \
+        >/dev/null 2>&1
+    if [ "$?" = "0" ]; then
+
+        if [ -f "$CATALINA_PID" ]; then
+            log_success_msg "$DESC is not running, but pid file exists."
+            exit 1
+        else
+            log_success_msg "$DESC is not running."
+            exit 3
+        fi
+    else
+        log_success_msg "$DESC is running with pid `cat $CATALINA_PID`"
+    fi
+    set -e
+        ;;
+  restart|force-reload)
+    if [ -f "$CATALINA_PID" ]; then
+        $0 stop
+        sleep 1
+    fi
+    $0 start
+    ;;
+  try-restart)
+        if start-stop-daemon --test --start --pidfile "$CATALINA_PID" \
+        --user $TOMCAT_USER --exec "$JAVA_HOME/bin/java" \
+        >/dev/null; then
+        $0 start
+    fi
+        ;;
+  *)
+    log_success_msg "Usage: $0 {start|stop|restart|try-restart|force-reload|status}"
+    exit 1
+    ;;
+esac
+
+exit 0


### PR DESCRIPTION
I don't know how useful this is to you, with the release of 17.3 on the horizon, but I went through the exercise of porting this to 17.2, so I thought I'd share it with you.

As the original setup had a directory for 16.3 I duplicated that for 17.2, even if it was a bit of overkill.

The directory in the tarball changed from starting with "LabKey" in 16.3, to "Labkey" in 17.2. The change in case of the "k" is easy to miss.

I've updated the README.md for completeness, but as I don't have an alternative for the 17.3 release that was downloaded from Amazon Web Services, I simply changed the 16.3 to 17.2 for that example.

All the other examples build and run happily for me.